### PR TITLE
Move application logic to browser-only version

### DIFF
--- a/bluesky-analyzer-react/src/App.jsx
+++ b/bluesky-analyzer-react/src/App.jsx
@@ -480,6 +480,27 @@ const useBrowserAnalysis = () => {
         }
       };
 
+      // Cache for follower counts we've already fetched
+      const followerCounts = new Map();
+
+      // Helper to get top results with follower counts
+      const getTopResults = () => {
+        return Array.from(followsOfFollows.entries())
+          .filter(([h, count]) =>
+            !userFollows.has(h) &&
+            count > MIN_COMMON_FOLLOWS &&
+            h !== 'handle.invalid' &&
+            h !== handle
+          )
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, MAX_RESULTS)
+          .map(([h, count]) => ({
+            handle: h,
+            count,
+            followers: followerCounts.get(h) || 0
+          }));
+      };
+
       // Process in concurrent batches
       for (let i = 0; i < followsArray.length; i += CONCURRENT_REQUESTS) {
         if (abortRef.current) break;
@@ -490,50 +511,51 @@ const useBrowserAnalysis = () => {
 
         setProgress({ processed, total: userFollows.size });
 
-        // Generate intermediate results every few batches
+        // Generate intermediate results and fetch follower counts for top results
         if (processed % 10 === 0 || processed === userFollows.size) {
-          const intermediateResults = Array.from(followsOfFollows.entries())
-            .filter(([h, count]) =>
-              !userFollows.has(h) &&
-              count > MIN_COMMON_FOLLOWS &&
-              h !== 'handle.invalid' &&
-              h !== handle
-            )
-            .sort((a, b) => b[1] - a[1])
-            .slice(0, MAX_RESULTS)
-            .map(([h, count]) => ({ handle: h, count, followers: 0 }));
+          const currentTop = getTopResults();
 
-          setResults(intermediateResults);
+          // Fetch follower counts for top results that we don't have yet (limit to top 50 for speed)
+          const needFollowerCounts = currentTop
+            .slice(0, 50)
+            .filter(r => !followerCounts.has(r.handle));
+
+          if (needFollowerCounts.length > 0) {
+            const counts = await Promise.all(
+              needFollowerCounts.map(async (r) => {
+                const followers = await api.getFollowerCount(r.handle);
+                return { handle: r.handle, followers };
+              })
+            );
+            counts.forEach(({ handle, followers }) => {
+              followerCounts.set(handle, followers);
+            });
+          }
+
+          setResults(getTopResults());
         }
       }
 
       if (abortRef.current) return;
 
-      // Step 3: Get follower counts for top results
-      const finalResults = Array.from(followsOfFollows.entries())
-        .filter(([h, count]) =>
-          !userFollows.has(h) &&
-          count > MIN_COMMON_FOLLOWS &&
-          h !== 'handle.invalid' &&
-          h !== handle
-        )
-        .sort((a, b) => b[1] - a[1])
-        .slice(0, MAX_RESULTS);
+      // Final pass: ensure all results have follower counts
+      const finalResults = getTopResults();
+      const remaining = finalResults.filter(r => !followerCounts.has(r.handle));
 
-      // Fetch follower counts in batches
-      const resultsWithFollowers = [];
-      for (let i = 0; i < finalResults.length; i += 10) {
+      for (let i = 0; i < remaining.length; i += 10) {
         if (abortRef.current) break;
 
-        const batch = finalResults.slice(i, i + 10);
-        const batchResults = await Promise.all(
-          batch.map(async ([h, count]) => {
-            const followers = await api.getFollowerCount(h);
-            return { handle: h, count, followers };
+        const batch = remaining.slice(i, i + 10);
+        const counts = await Promise.all(
+          batch.map(async (r) => {
+            const followers = await api.getFollowerCount(r.handle);
+            return { handle: r.handle, followers };
           })
         );
-        resultsWithFollowers.push(...batchResults);
-        setResults([...resultsWithFollowers]);
+        counts.forEach(({ handle, followers }) => {
+          followerCounts.set(handle, followers);
+        });
+        setResults(getTopResults());
       }
 
       setIsAnalyzing(false);

--- a/bluesky-analyzer-react/src/App.jsx
+++ b/bluesky-analyzer-react/src/App.jsx
@@ -1,14 +1,173 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Loader2, User, Lock, EyeOff, Eye, LockOpen 
-  ,
-  ExternalLink
-} from 'lucide-react';
+import { Loader2, User, Lock, EyeOff, Eye, LockOpen, ExternalLink } from 'lucide-react';
 import { PiButterflyFill } from "react-icons/pi";
-
 import { BskyAgent } from '@atproto/api';
+import { Toaster, toast } from 'react-hot-toast';
 
-import {Toaster, toast} from 'react-hot-toast';
+// Cache configuration
+const CACHE_TTL = 3600 * 12 * 1000; // 12 hours in milliseconds
+const CACHE_PREFIX = 'bsky_follows_';
+const FOLLOWER_CACHE_PREFIX = 'bsky_followers_';
 
+// Rate limiting configuration - be conservative for browser
+const REQUESTS_PER_SECOND = 8;
+const REQUEST_INTERVAL = 1000 / REQUESTS_PER_SECOND;
+
+// Analysis configuration
+const MIN_COMMON_FOLLOWS = 5;
+const MAX_RESULTS = 1500;
+const CONCURRENT_REQUESTS = 4;
+
+// Simple rate limiter
+class RateLimiter {
+  constructor(requestsPerSecond) {
+    this.minInterval = 1000 / requestsPerSecond;
+    this.lastRequestTime = 0;
+    this.queue = [];
+    this.processing = false;
+  }
+
+  async acquire() {
+    return new Promise((resolve) => {
+      this.queue.push(resolve);
+      this.processQueue();
+    });
+  }
+
+  async processQueue() {
+    if (this.processing || this.queue.length === 0) return;
+    this.processing = true;
+
+    while (this.queue.length > 0) {
+      const now = Date.now();
+      const timeSinceLastRequest = now - this.lastRequestTime;
+
+      if (timeSinceLastRequest < this.minInterval) {
+        await new Promise(r => setTimeout(r, this.minInterval - timeSinceLastRequest));
+      }
+
+      this.lastRequestTime = Date.now();
+      const resolve = this.queue.shift();
+      resolve();
+    }
+
+    this.processing = false;
+  }
+}
+
+// LocalStorage cache helpers
+const getFromCache = (key) => {
+  try {
+    const item = localStorage.getItem(key);
+    if (!item) return null;
+
+    const { data, timestamp } = JSON.parse(item);
+    if (Date.now() - timestamp > CACHE_TTL) {
+      localStorage.removeItem(key);
+      return null;
+    }
+    return data;
+  } catch {
+    return null;
+  }
+};
+
+const setInCache = (key, data) => {
+  try {
+    localStorage.setItem(key, JSON.stringify({
+      data,
+      timestamp: Date.now()
+    }));
+  } catch (e) {
+    // localStorage might be full, try to clear old entries
+    console.warn('Cache write failed:', e);
+  }
+};
+
+// Bluesky API client for browser
+class BlueskyBrowserAPI {
+  constructor() {
+    this.rateLimiter = new RateLimiter(REQUESTS_PER_SECOND);
+  }
+
+  async getFollows(actor, limit = 100, cursor = null) {
+    await this.rateLimiter.acquire();
+
+    const params = new URLSearchParams({ actor, limit: limit.toString() });
+    if (cursor) params.set('cursor', cursor);
+
+    const response = await fetch(
+      `https://public.api.bsky.app/xrpc/app.bsky.graph.getFollows?${params}`,
+      { headers: { 'Accept': 'application/json' } }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch follows for ${actor}: ${response.status}`);
+    }
+
+    return response.json();
+  }
+
+  async getAllFollows(actor, useCache = true) {
+    const cacheKey = `${CACHE_PREFIX}${actor}`;
+
+    if (useCache) {
+      const cached = getFromCache(cacheKey);
+      if (cached) {
+        return new Set(cached);
+      }
+    }
+
+    const follows = new Set();
+    let cursor = null;
+
+    try {
+      while (true) {
+        const response = await this.getFollows(actor, 100, cursor);
+
+        for (const follow of response.follows || []) {
+          follows.add(follow.handle);
+        }
+
+        if (!response.cursor) break;
+        cursor = response.cursor;
+      }
+
+      // Cache the results
+      setInCache(cacheKey, Array.from(follows));
+    } catch (error) {
+      console.error(`Error fetching follows for ${actor}:`, error);
+    }
+
+    return follows;
+  }
+
+  async getFollowerCount(actor) {
+    const cacheKey = `${FOLLOWER_CACHE_PREFIX}${actor}`;
+    const cached = getFromCache(cacheKey);
+    if (cached !== null) {
+      return cached;
+    }
+
+    await this.rateLimiter.acquire();
+
+    try {
+      const response = await fetch(
+        `https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=${actor}`,
+        { headers: { 'Accept': 'application/json' } }
+      );
+
+      if (!response.ok) return 0;
+
+      const data = await response.json();
+      const count = data.followersCount || 0;
+      setInCache(cacheKey, count);
+      return count;
+    } catch {
+      return 0;
+    }
+  }
+}
 
 const WeightToggle = ({ weighted, onToggle }) => {
   return (
@@ -27,7 +186,7 @@ const WeightToggle = ({ weighted, onToggle }) => {
           Sort by total (favours larger accounts)
         </label>
       </div>
-      
+
       <div className="flex items-center">
         <input
           type="radio"
@@ -46,27 +205,20 @@ const WeightToggle = ({ weighted, onToggle }) => {
   );
 };
 
-
 const calculateWilsonScore = (positive, total, confidence = 0.95) => {
   if (total === 0) return 0;
-  
-  // z score for confidence level (0.95 = 1.96)
+
   const z = 1.96;
-  
   const phat = positive / total;
   const z2 = z * z;
   const n = total;
-  
-  // Wilson score interval lower bound formula
+
   const numerator = phat + z2/(2*n) - z * Math.sqrt((phat*(1-phat) + z2/(4*n))/n);
   const denominator = 1 + z2/n;
-  
+
   return numerator/denominator;
 };
 
-
-
-// Keep existing cache setup
 const profileCache = new Map();
 const pendingRequests = new Map();
 
@@ -74,25 +226,19 @@ const FollowButton = ({ handle, appPassword, username, className = "" }) => {
   const [isFollowing, setIsFollowing] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
-  if(handle===username) {
-    return null
-  }
-
-  if(!appPassword) {
-    return null
-  }
-
+  if (handle === username) return null;
+  if (!appPassword) return null;
 
   const handleFollowAction = async () => {
     if (isLoading || !appPassword || !username) return;
-    
+
     setIsLoading(true);
     try {
       const agent = new BskyAgent({ service: 'https://bsky.social' });
       await agent.login({ identifier: username, password: appPassword });
-      
-      const { data } = await agent.getProfile({ actor: handle })
-      const { did, displayName } = data
+
+      const { data } = await agent.getProfile({ actor: handle });
+      const { did } = data;
 
       if (!isFollowing) {
         await agent.follow(did);
@@ -103,7 +249,7 @@ const FollowButton = ({ handle, appPassword, username, className = "" }) => {
       }
     } catch (error) {
       console.error('Follow action failed:', error);
-      toast.error('Failed to follow. Maybe the app password is wrong? Or we may have exceeded the Bluesky rate limit for following. '+error);
+      toast.error('Failed to follow. Maybe the app password is wrong? Or we may have exceeded the Bluesky rate limit for following. ' + error);
     } finally {
       setIsLoading(false);
     }
@@ -134,7 +280,6 @@ const FollowButton = ({ handle, appPassword, username, className = "" }) => {
 
 const useBlueskyProfiles = () => {
   const [profiles, setProfiles] = useState({});
-  const [loadingHandles, setLoadingHandles] = useState(new Set());
 
   const fetchProfile = useCallback(async (handle) => {
     if (profileCache.has(handle)) {
@@ -145,54 +290,37 @@ const useBlueskyProfiles = () => {
       return pendingRequests.get(handle);
     }
 
-    setLoadingHandles(prev => new Set([...prev, handle]));
-
     const requestPromise = (async () => {
       try {
-        const response = await fetch(`https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=${handle}`, {
-          method: 'GET',
-          headers: {
-            'Accept': 'application/json',
-          }
-        });
-        
+        const response = await fetch(
+          `https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=${handle}`,
+          { headers: { 'Accept': 'application/json' } }
+        );
+
         if (!response.ok) throw new Error('Profile fetch failed');
-        
+
         const data = await response.json();
         profileCache.set(handle, data);
         pendingRequests.delete(handle);
-        setLoadingHandles(prev => {
-          const next = new Set(prev);
-          next.delete(handle);
-          return next;
-        });
         return data;
       } catch (error) {
         console.error(`Error fetching profile for ${handle}:`, error);
         pendingRequests.delete(handle);
-        setLoadingHandles(prev => {
-          const next = new Set(prev);
-          next.delete(handle);
-          return next;
-        });
         return null;
       }
     })();
 
     pendingRequests.set(handle, requestPromise);
-    
+
     const profile = await requestPromise;
     if (profile) {
-      setProfiles(prev => ({
-        ...prev,
-        [handle]: profile
-      }));
+      setProfiles(prev => ({ ...prev, [handle]: profile }));
     }
-    
+
     return profile;
   }, []);
 
-  return { profiles, fetchProfile, loadingHandles };
+  return { profiles, fetchProfile };
 };
 
 const ResultItem = ({ item, index, onInView, handleToAnalyze, appPassword, weightedEnabled }) => {
@@ -205,37 +333,19 @@ const ResultItem = ({ item, index, onInView, handleToAnalyze, appPassword, weigh
           if (entry.isIntersecting) {
             onInView(item.handle);
             viewObserver.unobserve(entry.target);
-            preloadObserver.unobserve(entry.target);
           }
         });
       },
-      { threshold: 0.1 }
-    );
-
-    const preloadObserver = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            onInView(item.handle);
-            preloadObserver.unobserve(entry.target);
-          }
-        });
-      },
-      {
-        rootMargin: '50% 0px 50% 0px',
-        threshold: 0
-      }
+      { threshold: 0.1, rootMargin: '50% 0px 50% 0px' }
     );
 
     if (itemRef.current) {
       viewObserver.observe(itemRef.current);
-      preloadObserver.observe(itemRef.current);
     }
 
     return () => {
       if (itemRef.current) {
         viewObserver.unobserve(itemRef.current);
-        preloadObserver.unobserve(itemRef.current);
       }
     };
   }, [item.handle, onInView]);
@@ -243,7 +353,7 @@ const ResultItem = ({ item, index, onInView, handleToAnalyze, appPassword, weigh
   const getBskyUrl = (handle) => `https://bsky.app/profile/${handle}`;
 
   return (
-    <div 
+    <div
       ref={itemRef}
       className="flex items-center gap-3 p-3 border-b last:border-b-0 hover:bg-gray-50 transition-colors"
     >
@@ -252,8 +362,8 @@ const ResultItem = ({ item, index, onInView, handleToAnalyze, appPassword, weigh
       </span>
       <div className="w-10 h-10 rounded-full overflow-hidden bg-gray-100 flex-shrink-0">
         {item.profile?.avatar ? (
-          <img 
-            src={item.profile.avatar} 
+          <img
+            src={item.profile.avatar}
             alt={item.profile.displayName || item.handle}
             className="w-full h-full object-cover"
           />
@@ -266,9 +376,9 @@ const ResultItem = ({ item, index, onInView, handleToAnalyze, appPassword, weigh
       <div className="flex flex-1 justify-between items-start gap-2 min-w-0">
         <div className="flex flex-col min-w-0 max-w-32 md:max-w-none">
           <div className="flex items-center gap-2">
-            <a 
-              href={getBskyUrl(item.handle)} 
-              target="_blank" 
+            <a
+              href={getBskyUrl(item.handle)}
+              target="_blank"
               rel="noopener noreferrer"
               className="font-medium text-sky-900 hover:text-sky-800 hover:underline truncate"
             >
@@ -277,7 +387,7 @@ const ResultItem = ({ item, index, onInView, handleToAnalyze, appPassword, weigh
                 <span className="text-xs text-sky-500 ml-1">(You)</span>
               )}
             </a>
-            <FollowButton 
+            <FollowButton
               appPassword={appPassword}
               handle={item.handle}
               username={handleToAnalyze}
@@ -290,20 +400,16 @@ const ResultItem = ({ item, index, onInView, handleToAnalyze, appPassword, weigh
               : item.handle}
           </span>
           {item.profile?.description && (
-            <p className="text-xs text-sky-600 mt-1 line-clamp-2"
-            title={item.profile.description}>
+            <p className="text-xs text-sky-600 mt-1 line-clamp-2" title={item.profile.description}>
               {item.profile.description}
             </p>
           )}
         </div>
         <div className="text-right flex-shrink-0 text-sky-800">
-          <span className="text-sm font-medium">{item.count}
-            {weightedEnabled &&
-            <span>/{item.followers}</span>
-            }
-            
-            
-            </span>
+          <span className="text-sm font-medium">
+            {item.count}
+            {weightedEnabled && <span>/{item.followers}</span>}
+          </span>
           <span className="text-xs block">follows</span>
         </div>
       </div>
@@ -311,21 +417,152 @@ const ResultItem = ({ item, index, onInView, handleToAnalyze, appPassword, weigh
   );
 };
 
-// Main component with app password functionality
+// Browser-based analysis hook
+const useBrowserAnalysis = () => {
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const [progress, setProgress] = useState({ processed: 0, total: 0 });
+  const [results, setResults] = useState([]);
+  const [error, setError] = useState(null);
+  const abortRef = useRef(false);
+  const apiRef = useRef(null);
+
+  const analyze = useCallback(async (handle) => {
+    abortRef.current = false;
+    setIsAnalyzing(true);
+    setResults([]);
+    setError(null);
+    setProgress({ processed: 0, total: 0 });
+
+    if (!apiRef.current) {
+      apiRef.current = new BlueskyBrowserAPI();
+    }
+    const api = apiRef.current;
+
+    try {
+      // Step 1: Get the user's follows (don't use cache for this to get fresh data)
+      const userFollows = await api.getAllFollows(handle, false);
+
+      if (userFollows.size === 0) {
+        setError('No follows found for this user. Check the handle is correct.');
+        setIsAnalyzing(false);
+        return;
+      }
+
+      setProgress({ processed: 0, total: userFollows.size });
+
+      // Step 2: For each follow, get their follows and count
+      const followsOfFollows = new Map(); // handle -> count
+      const followsArray = Array.from(userFollows);
+      let processed = 0;
+
+      // Process in batches for better performance
+      const processBatch = async (batch) => {
+        const promises = batch.map(async (followHandle) => {
+          if (abortRef.current) return;
+
+          try {
+            const theirFollows = await api.getAllFollows(followHandle, true);
+            return { handle: followHandle, follows: theirFollows };
+          } catch (err) {
+            console.error(`Error fetching follows for ${followHandle}:`, err);
+            return { handle: followHandle, follows: new Set() };
+          }
+        });
+
+        const results = await Promise.all(promises);
+
+        for (const { follows } of results) {
+          if (abortRef.current) return;
+
+          for (const h of follows) {
+            followsOfFollows.set(h, (followsOfFollows.get(h) || 0) + 1);
+          }
+        }
+      };
+
+      // Process in concurrent batches
+      for (let i = 0; i < followsArray.length; i += CONCURRENT_REQUESTS) {
+        if (abortRef.current) break;
+
+        const batch = followsArray.slice(i, i + CONCURRENT_REQUESTS);
+        await processBatch(batch);
+        processed += batch.length;
+
+        setProgress({ processed, total: userFollows.size });
+
+        // Generate intermediate results every few batches
+        if (processed % 10 === 0 || processed === userFollows.size) {
+          const intermediateResults = Array.from(followsOfFollows.entries())
+            .filter(([h, count]) =>
+              !userFollows.has(h) &&
+              count > MIN_COMMON_FOLLOWS &&
+              h !== 'handle.invalid' &&
+              h !== handle
+            )
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, MAX_RESULTS)
+            .map(([h, count]) => ({ handle: h, count, followers: 0 }));
+
+          setResults(intermediateResults);
+        }
+      }
+
+      if (abortRef.current) return;
+
+      // Step 3: Get follower counts for top results
+      const finalResults = Array.from(followsOfFollows.entries())
+        .filter(([h, count]) =>
+          !userFollows.has(h) &&
+          count > MIN_COMMON_FOLLOWS &&
+          h !== 'handle.invalid' &&
+          h !== handle
+        )
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, MAX_RESULTS);
+
+      // Fetch follower counts in batches
+      const resultsWithFollowers = [];
+      for (let i = 0; i < finalResults.length; i += 10) {
+        if (abortRef.current) break;
+
+        const batch = finalResults.slice(i, i + 10);
+        const batchResults = await Promise.all(
+          batch.map(async ([h, count]) => {
+            const followers = await api.getFollowerCount(h);
+            return { handle: h, count, followers };
+          })
+        );
+        resultsWithFollowers.push(...batchResults);
+        setResults([...resultsWithFollowers]);
+      }
+
+      setIsAnalyzing(false);
+    } catch (err) {
+      console.error('Analysis error:', err);
+      setError(`Analysis failed: ${err.message}`);
+      setIsAnalyzing(false);
+    }
+  }, []);
+
+  const abort = useCallback(() => {
+    abortRef.current = true;
+    setIsAnalyzing(false);
+  }, []);
+
+  return { analyze, abort, isAnalyzing, progress, results, error };
+};
+
+// Main component
 const BlueskyAnalyzer = () => {
   const [inputValue, setInputValue] = useState('');
   const [handleToAnalyze, setHandleToAnalyze] = useState('');
-  const [results, setResults] = useState([]);
-  const [progress, setProgress] = useState({ processed: 0, total: 0 });
-  const [error, setError] = useState(null);
-  const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [appPassword, setAppPassword] = useState('');
   const [showAppPassword, setShowAppPassword] = useState(false);
   const [showAppPasswordSection, setShowAppPasswordSection] = useState(false);
   const [weightedEnabled, setWeightedEnabled] = useState(false);
-  
 
-  const { profiles, fetchProfile, loadingHandles } = useBlueskyProfiles();
+  const { analyze, abort, isAnalyzing, progress, results, error } = useBrowserAnalysis();
+  const { profiles, fetchProfile } = useBlueskyProfiles();
 
   let enhancedResults = results.map(result => ({
     ...result,
@@ -333,96 +570,40 @@ const BlueskyAnalyzer = () => {
   }));
 
   if (weightedEnabled) {
-    enhancedResults = enhancedResults.map(result => ({
-      ...result,
-      score: calculateWilsonScore(result.count, result.followers)
-    })).sort((a, b) => b.score - a.score);
+    enhancedResults = enhancedResults
+      .map(result => ({
+        ...result,
+        score: calculateWilsonScore(result.count, result.followers)
+      }))
+      .sort((a, b) => b.score - a.score);
   }
-
-
-
-  
 
   const handleInView = useCallback((handle) => {
     fetchProfile(handle);
   }, [fetchProfile]);
 
-  useEffect(() => {
-    let eventSource = null;
-
-    const startAnalysis = () => {
-      if (!handleToAnalyze.trim()) return;
-      
-      if (eventSource) {
-        eventSource.close();
-      }
-
-      setIsAnalyzing(true);
-      setResults([]);
-      setError(null);
-
-      eventSource = new EventSource(`//bsky-follow-suggestions.theo.io/analyze/${handleToAnalyze}`);
-
-      eventSource.addEventListener('update', (e) => {
-        try {
-          const data = JSON.parse(e.data);
-          setResults(data.results);
-          setProgress({
-            processed: data.processed_count,
-            total: data.total_count
-          });
-          if( data.processed_count &&  data.processed_count == data.total_count){
-            window.finished = true
-          }
-        } catch (err) {
-          setError('Failed to parse server data');
-        }
-      });
-
-      eventSource.addEventListener('error', (e) => {
-        setIsAnalyzing(false);
-        try {
-          const data = JSON.parse(e.data);
-          setError(data.error);
-        } catch (err) {
-          if (!window.finished){
-          setError('Something went wrong: sometimes this means you mistyped your username. Please try again.');
-          }
-        }
-        eventSource.close();
-      });
-    };
-
-    if (isAnalyzing) {
-      startAnalysis();
-    }
-
-    return () => {
-      if (eventSource) {
-        eventSource.close();
-      }
-    };
-  }, [handleToAnalyze, isAnalyzing]);
-
   const handleSubmit = (e) => {
     e.preventDefault();
     let processedHandle = inputValue.trim();
-    
-     processedHandle = processedHandle.replace(/[^\x00-\x7F]/g, '');
-    
+    processedHandle = processedHandle.replace(/[^\x00-\x7F]/g, '');
+
     if (!processedHandle.includes('.')) {
       processedHandle = `${processedHandle}.bsky.social`;
     }
-    
+
     if (processedHandle.startsWith('@')) {
       processedHandle = processedHandle.slice(1);
     }
 
-
-    setHandleToAnalyze(processedHandle.toLowerCase());
-    setIsAnalyzing(true);
-    window.finished=false;
+    const finalHandle = processedHandle.toLowerCase();
+    setHandleToAnalyze(finalHandle);
+    analyze(finalHandle);
   };
+
+  const handleCancel = () => {
+    abort();
+  };
+
   return (
     <div className="min-h-screen bg-gradient-to-b from-sky-50 to-white p-4 md:p-8">
       <Toaster />
@@ -436,10 +617,10 @@ const BlueskyAnalyzer = () => {
           </div>
           <p className="text-sky-600 text-sm">
             made by{' '}
-            <a 
-              href="https://bsky.app/profile/theo.io" 
-              target="_blank" 
-              rel="noopener noreferrer" 
+            <a
+              href="https://bsky.app/profile/theo.io"
+              target="_blank"
+              rel="noopener noreferrer"
               className="text-sky-500 hover:text-sky-700 hover:underline"
             >
               @theo.io
@@ -451,71 +632,81 @@ const BlueskyAnalyzer = () => {
           Enter your Bluesky handle below to find people followed by lots of the people you follow (but not you).
         </p>
 
+        <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 mb-4 text-sm text-amber-800">
+          <strong>Browser-only version:</strong> This runs entirely in your browser. Analysis may take several minutes for accounts with many follows. Your data never leaves your device.
+        </div>
+
         <div className="bg-white/80 backdrop-blur-sm rounded-lg shadow-lg shadow-sky-100/50 p-6 mb-4 border border-sky-100">
           <form onSubmit={handleSubmit} className="flex flex-col gap-4">
             <div className="flex flex-col md:flex-row gap-4">
-              <input 
-                type="text" 
+              <input
+                type="text"
                 value={inputValue}
                 onChange={(e) => setInputValue(e.target.value)}
-                placeholder="Enter Bluesky handle (e.g., user.bsky.social)" 
+                placeholder="Enter Bluesky handle (e.g., user.bsky.social)"
                 className="flex-1 p-2 border border-sky-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-sky-500 bg-white/90"
+                disabled={isAnalyzing}
               />
-              <button 
-                type="submit"
-                className="bg-sky-500 text-white px-6 py-2 rounded-lg hover:bg-sky-600 transition-colors shadow-sm hover:shadow-md"
-              >
-                Analyze
-              </button>
+              {isAnalyzing ? (
+                <button
+                  type="button"
+                  onClick={handleCancel}
+                  className="bg-red-500 text-white px-6 py-2 rounded-lg hover:bg-red-600 transition-colors shadow-sm hover:shadow-md"
+                >
+                  Cancel
+                </button>
+              ) : (
+                <button
+                  type="submit"
+                  className="bg-sky-500 text-white px-6 py-2 rounded-lg hover:bg-sky-600 transition-colors shadow-sm hover:shadow-md"
+                >
+                  Analyze
+                </button>
+              )}
             </div>
-            
+
             {!showAppPasswordSection ? (
-
-              ( isAnalyzing || results.length >0) &&
-              <button
-                type="button"
-                onClick={() => setShowAppPasswordSection(true)}
-                className="text-sky-600 hover:text-sky-500 text-sm flex items-center gap-2 self-start"
-              >
-                <LockOpen className="w-4 h-4" />
-                Add an app password to enable follow buttons (optional)
-              </button>
-
-            
+              (isAnalyzing || results.length > 0) && (
+                <button
+                  type="button"
+                  onClick={() => setShowAppPasswordSection(true)}
+                  className="text-sky-600 hover:text-sky-500 text-sm flex items-center gap-2 self-start"
+                >
+                  <LockOpen className="w-4 h-4" />
+                  Add an app password to enable follow buttons (optional)
+                </button>
+              )
             ) : (
               <>
-              <div className="flex flex-col md:flex-row gap-4 items-center">
-                <div className="relative flex-1">
-                  <input 
-                    type={showAppPassword ? "text" : "password"}
-                    value={appPassword}
-                    onChange={(e) => setAppPassword(e.target.value)}
-                    placeholder="Enter App Password to enable follow buttons" 
-                    className="w-full p-2 pr-10 border border-sky-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-sky-500 bg-white/90"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowAppPassword(!showAppPassword)}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 text-sky-500 hover:text-sky-600"
-                  >
-                    {showAppPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-                  </button>
+                <div className="flex flex-col md:flex-row gap-4 items-center">
+                  <div className="relative flex-1">
+                    <input
+                      type={showAppPassword ? "text" : "password"}
+                      value={appPassword}
+                      onChange={(e) => setAppPassword(e.target.value)}
+                      placeholder="Enter App Password to enable follow buttons"
+                      className="w-full p-2 pr-10 border border-sky-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-sky-500 bg-white/90"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowAppPassword(!showAppPassword)}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-sky-500 hover:text-sky-600"
+                    >
+                      {showAppPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                    </button>
+                  </div>
+                  <div className="text-sm text-sky-600 flex items-center gap-2">
+                    <Lock className="w-4 h-4" />
+                    Password is kept in local browser
+                  </div>
                 </div>
-                <div className="text-sm text-sky-600 flex items-center gap-2">
-                  <Lock className="w-4 h-4" />
-                  Password is kept in local browser
+                <div className="block">
+                  <a href="https://bsky.app/settings/app-passwords" target="_blank" rel="noopener noreferrer" className="text-sky-500 hover:text-sky-600 text-sm hover:underline">
+                    <ExternalLink className="w-4 h-4 inline-block mr-1" />
+                    Go to Bluesky settings to create an app password
+                  </a>
                 </div>
-                
-               
-              </div>
-               <div className="block">
-               <a href="https://bsky.app/settings/app-passwords" target="_blank" rel="noopener noreferrer" className="text-sky-500 hover:text-sky-600 text-sm hover:underline">
-               <ExternalLink className="w-4 h-4 inline-block mr-1" />
-               Go to Bluesky settings to create an app password
-               </a>
-               </div>
-               </>
-              
+              </>
             )}
           </form>
         </div>
@@ -523,11 +714,11 @@ const BlueskyAnalyzer = () => {
         <div className="bg-white/80 backdrop-blur-sm rounded-lg shadow-lg shadow-sky-100/50 p-6 border border-sky-100">
           <div className="flex justify-between items-center mb-4">
             <h2 className="text-xl font-semibold text-sky-700">Results</h2>
-            {isAnalyzing && progress.total > 0 && (
+            {progress.total > 0 && (
               <div className="text-sm text-sky-600 flex items-center">
-                {progress.processed !== 0&& progress.processed !== progress.total &&
+                {isAnalyzing && progress.processed !== progress.total && (
                   <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                }
+                )}
                 Processed {progress.processed}/{progress.total} follows
               </div>
             )}
@@ -540,43 +731,36 @@ const BlueskyAnalyzer = () => {
           ) : results.length === 0 && isAnalyzing ? (
             <div className="text-sky-600 text-center py-8">
               <Loader2 className="w-8 h-8 mx-auto mb-4 animate-spin" />
-              Initialising: finding the people you follow..
+              Initializing: finding the people you follow...
             </div>
           ) : (
-          <div>
-
-            {
-              results.length > 0 &&
-            
-            <WeightToggle weighted={weightedEnabled} onToggle={setWeightedEnabled} />
-}
-            
-
-
-            <div className="grid gap-3">
-              {enhancedResults.map((item, index) => (
-                <ResultItem
-                  key={item.handle}
-                  item={item}
-                  index={index}
-                  onInView={handleInView}
-                  handleToAnalyze={handleToAnalyze}
-                  appPassword={appPassword}
-                  weightedEnabled={weightedEnabled}
-                />
-              ))}
-              
-           
-              {results.length > 0 && !isAnalyzing && (
-                <div className="text-center py-4 text-sky-600 text-sm">
-                  Analysis complete! Found {results.length} suggestions.
-                </div> 
+            <div>
+              {results.length > 0 && (
+                <WeightToggle weighted={weightedEnabled} onToggle={setWeightedEnabled} />
               )}
+
+              <div className="grid gap-3">
+                {enhancedResults.map((item, index) => (
+                  <ResultItem
+                    key={item.handle}
+                    item={item}
+                    index={index}
+                    onInView={handleInView}
+                    handleToAnalyze={handleToAnalyze}
+                    appPassword={appPassword}
+                    weightedEnabled={weightedEnabled}
+                  />
+                ))}
+
+                {results.length > 0 && !isAnalyzing && (
+                  <div className="text-center py-4 text-sky-600 text-sm">
+                    Analysis complete! Found {results.length} suggestions.
+                  </div>
+                )}
+              </div>
             </div>
-          </div>
-            
           )}
-          
+
           {appPassword && results.length > 0 && (
             <div className="mt-4 p-4 bg-sky-50 rounded-lg border border-sky-100">
               <div className="flex items-center gap-2 text-sky-700 text-sm">
@@ -588,8 +772,6 @@ const BlueskyAnalyzer = () => {
             </div>
           )}
         </div>
-        
-      
       </div>
     </div>
   );

--- a/bluesky-analyzer-react/src/App.jsx
+++ b/bluesky-analyzer-react/src/App.jsx
@@ -16,7 +16,9 @@ const REQUEST_INTERVAL = 1000 / REQUESTS_PER_SECOND;
 // Analysis configuration
 const MIN_COMMON_FOLLOWS = 5;
 const MAX_RESULTS = 1500;
+const DISPLAY_RESULTS = 200; // Limit displayed results for performance
 const CONCURRENT_REQUESTS = 4;
+const UPDATE_INTERVAL = 100; // Update UI every N processed follows
 
 // Simple rate limiter
 class RateLimiter {
@@ -512,7 +514,7 @@ const useBrowserAnalysis = () => {
         setProgress({ processed, total: userFollows.size });
 
         // Generate intermediate results and fetch follower counts for top results
-        if (processed % 10 === 0 || processed === userFollows.size) {
+        if (processed % UPDATE_INTERVAL === 0 || processed === userFollows.size) {
           const currentTop = getTopResults();
 
           // Fetch follower counts for top results that we don't have yet (limit to top 50 for speed)
@@ -599,6 +601,9 @@ const BlueskyAnalyzer = () => {
       }))
       .sort((a, b) => b.score - a.score);
   }
+
+  // Limit displayed results for performance
+  const displayedResults = enhancedResults.slice(0, DISPLAY_RESULTS);
 
   const handleInView = useCallback((handle) => {
     fetchProfile(handle);
@@ -762,7 +767,7 @@ const BlueskyAnalyzer = () => {
               )}
 
               <div className="grid gap-3">
-                {enhancedResults.map((item, index) => (
+                {displayedResults.map((item, index) => (
                   <ResultItem
                     key={item.handle}
                     item={item}
@@ -776,7 +781,7 @@ const BlueskyAnalyzer = () => {
 
                 {results.length > 0 && !isAnalyzing && (
                   <div className="text-center py-4 text-sky-600 text-sm">
-                    Analysis complete! Found {results.length} suggestions.
+                    Analysis complete! Showing top {displayedResults.length} of {results.length} suggestions.
                   </div>
                 )}
               </div>

--- a/bluesky-analyzer-react/src/App.jsx
+++ b/bluesky-analyzer-react/src/App.jsx
@@ -408,7 +408,7 @@ const ResultItem = ({ item, index, onInView, handleToAnalyze, appPassword, weigh
         <div className="text-right flex-shrink-0 text-sky-800">
           <span className="text-sm font-medium">
             {item.count}
-            {weightedEnabled && <span>/{item.followers}</span>}
+            {weightedEnabled && item.followers > 0 && <span>/{item.followers}</span>}
           </span>
           <span className="text-xs block">follows</span>
         </div>

--- a/bluesky-analyzer-react/src/App.jsx
+++ b/bluesky-analyzer-react/src/App.jsx
@@ -18,7 +18,7 @@ const MIN_COMMON_FOLLOWS = 5;
 const MAX_RESULTS = 1500;
 const DISPLAY_RESULTS = 200; // Limit displayed results for performance
 const CONCURRENT_REQUESTS = 4;
-const UPDATE_INTERVAL = 100; // Update UI every N processed follows
+const UPDATE_INTERVAL_MS = 5000; // Update UI every 5 seconds
 
 // Simple rate limiter
 class RateLimiter {
@@ -504,6 +504,8 @@ const useBrowserAnalysis = () => {
       };
 
       // Process in concurrent batches
+      let lastUpdateTime = Date.now();
+
       for (let i = 0; i < followsArray.length; i += CONCURRENT_REQUESTS) {
         if (abortRef.current) break;
 
@@ -513,8 +515,10 @@ const useBrowserAnalysis = () => {
 
         setProgress({ processed, total: userFollows.size });
 
-        // Generate intermediate results and fetch follower counts for top results
-        if (processed % UPDATE_INTERVAL === 0 || processed === userFollows.size) {
+        // Generate intermediate results every 5 seconds or at the end
+        const now = Date.now();
+        if (now - lastUpdateTime >= UPDATE_INTERVAL_MS || processed === userFollows.size) {
+          lastUpdateTime = now;
           const currentTop = getTopResults();
 
           // Fetch follower counts for top results that we don't have yet (limit to top 50 for speed)


### PR DESCRIPTION
Replace server-side analysis with client-side processing:
- Add BlueskyBrowserAPI class to call Bluesky API directly from browser
- Implement localStorage caching with 12-hour TTL for follows data
- Add rate limiter (8 req/sec) to avoid API limits
- Add cancel button for long-running analyses
- Show intermediate results during analysis
- Add informational banner about browser-only mode